### PR TITLE
add github actions build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,66 @@
+# https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions
+name: Build
+
+on:
+  push:
+    branches:
+    - '**'
+    tags-ignore:
+    - '**'
+  pull_request:
+  workflow_dispatch:
+    # https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Git Checkout
+      uses: actions/checkout@v2 #https://github.com/actions/checkout
+
+    - name: Set up JDK 11
+      uses: actions/setup-java@v2 # https://github.com/actions/setup-java
+      with:
+        distribution: 'zulu'
+        java-version: 11
+
+    - name: "Cache: Local Maven Repository"
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.m2/repository
+          !~/.m2/com/bytedance
+        key: ${{ runner.os }}-mvnrepo-${{ hashFiles('**/build.gradle') }}
+        restore-keys: |
+          ${{ runner.os }}-mvnrepo-
+
+    - name: Build with Gradle
+      run: |
+        set -eux
+
+        bash ./gradlew publishToMavenLocal
+
+    - name: Deploy Maven Repo
+      run: |
+        set -eux
+
+        if git checkout --orphan mvn-repo; then
+          git rm -rf .
+          git clean -fxd
+        fi
+ 
+        # https://github.community/t/github-actions-bot-email-address/17204
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+        mkdir -p com/bytedance/android
+        cp -rf ~/.m2/repository/com/bytedance/android/* com/bytedance/android
+
+        git add --all
+        git commit -am "deploy to maven repo"
+        git push origin mvn-repo --force

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@
 - **???:** Looking ahead, there will be more feature support, welcome to submit PR & issue.
 
 ## [Data of size savings](wiki/en/DATA.md)
-**AabResGuard** is a resource obfuscation tool powered by the douyin Android team. It has been launched at the end of July 2018 in several overseas products, such as **Tiktok, Vigo**, etc. 
-There is no feedback on related resource issues. 
+**AabResGuard** is a resource obfuscation tool powered by the douyin Android team. It has been launched at the end of July 2018 in several overseas products, such as **Tiktok, Vigo**, etc.
+There is no feedback on related resource issues.
 For more data details, please go to **[Data of size savings](wiki/en/DATA.md)**.
 
 ## Quick start
@@ -40,6 +40,7 @@ buildscript {
     mavenLocal()
     jcenter()
     google()
+    maven { url 'https://raw.githubusercontent.com/martinloren/AabResGuard/mvn-repo' }
    }
   dependencies {
     classpath "com.bytedance.android:aabresguard-plugin:0.1.10"
@@ -77,7 +78,7 @@ aabResGuard {
         "*/arm64-v8a/*",
         "META-INF/*"
     ]
-    
+
     enableFilterStrings = false // switch of filter strings
     unusedStringPath = file("unused.txt").toPath() // strings will be filtered in this file
     languageWhiteList = ["en", "zh"] // keep en,en-xx,zh,zh-xx etc. remove others.

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,7 +24,7 @@ PUBLISH_LOCAL_REPO=../repo
 useLocalMaven=true
 # 是否源码依赖
 useSource=true
-enableAabResGuardPlugin=true
+enableAabResGuardPlugin=false
 # bintray
 uploadToBintray=false
 bintrayInfo.user=****


### PR DESCRIPTION
This PR will add a github actions build job that runs on every commit on the `develop` branch and creates/updates a separate branch in this repository called `mvn-repo` that holds the binaries and can be referenced in gradle like this:

```gradle
buildscript {
  repositories {
    //...
    maven { url 'https://raw.githubusercontent.com/martinloren/AabResGuard/mvn-repo' }
  }
  //...
}
```