### PR TITLE
make @TaskAction open

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,8 @@ buildscript {
     apply from: rootProject.file("gradle/config.gradle")
     repositories {
         google()
+        maven { url 'https://maven.aliyun.com/repository/public/' }
+        maven { url 'https://raw.githubusercontent.com/martinloren/AabResGuard/mvn-repo' }
         if ("true".equalsIgnoreCase(System.getProperty('useLocalMaven', "false"))) {
             println "Using local repo."
             mavenLocal()
@@ -32,6 +34,8 @@ buildscript {
 allprojects {
     repositories {
         google()
+        maven { url 'https://maven.aliyun.com/repository/public/' }
+        maven { url 'https://raw.githubusercontent.com/martinloren/AabResGuard/mvn-repo' }
         if ("true".equalsIgnoreCase(System.getProperty('useLocalMaven', "false"))) {
             mavenLocal()
         } else {

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -1,8 +1,8 @@
 def versions = [:]
 versions.agp = "4.2.0"
 versions.kotlin = "1.3.61"
-versions.java = "8"
-versions.aabresguard = "0.1.10"
+versions.java = "11"
+versions.aabresguard = "0.1.11-alpha"
 // android
 versions.compileSdkVersion = 30//28
 versions.minSdkVersion = 15

--- a/plugin/src/main/kotlin/com/bytedance/android/plugin/tasks/AabResGuardTask.kt
+++ b/plugin/src/main/kotlin/com/bytedance/android/plugin/tasks/AabResGuardTask.kt
@@ -62,7 +62,7 @@ open class AabResGuardTask @Inject constructor(outputFactory: StyledTextOutputFa
     private val out = outputFactory.create("AabResGuardTask")
 
     @TaskAction
-    private fun execute() {
+    open fun execute() {
         out.style(Style.Info).println(aabResGuard.toString())
         // init signing config
         signingConfig = getSigningConfig(project, variant)


### PR DESCRIPTION
 Fixed @TaskAction [visibility issue](https://docs.gradle.org/8.14.3/userguide/validation_problems.html#private_method_must_not_be_annotated) for Gradle 8.x compatibility.
 Changed method visibility from private to public to comply with Gradle 8.x requirements.
 Version upgraded to 0.1.11-alpha due to this breaking change.
 Impact: Methods annotated with @TaskAction must now be public instead of private.